### PR TITLE
Make default last child as non-linkable

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -108,7 +108,7 @@ export default Component.extend({
       let breadCrumb = this._lookupRoute(path).getWithDefault('breadCrumb', undefined);
       const breadCrumbType = typeOf(breadCrumb);
 
-      if(index === pathLength - 1) {
+      if (index === pathLength - 1) {
         defaultLinkable = false;
       }
       if (breadCrumbType === 'undefined') {


### PR DESCRIPTION
Make default last child as non-linkable
for / bar / baz (baz will be non-linkable always)

to make baz as clickable, one can define it in the route.